### PR TITLE
chore: nginx volume 마운트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - "443:443" # SSL 붙일 때
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - /etc/letsencrypt:/etc/letsencrypt:ro   # 인증서 공유
     depends_on:
       - app
 


### PR DESCRIPTION
EC2에서 cerbot으로 인증서를 발급받음
그건 EC2에 있지 Docker로 띄운 nginx 컨테이너에는 인증서가 없다.
그래서 volume mount로 연결해줘야한다.
이때, `:ro` 사용해서 읽기 전용 옵션을 붙여 인증서 파일을 읽기만 가능하도록 안전하게 연결한다!